### PR TITLE
Readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ You can choose to use either the default async client or a blocking one.
 **async client:**
 
 ```toml
-musicbrainz_rs = "0.5.0"
+musicbrainz_rs_nova = "0.5.1"
 ```
 
 **blocking client:**
 
 ```toml
-musicbrainz_rs = { version = "0.5.0", features = ["blocking"] }
+musicbrainz_rs_nova = { version = "0.5.1", features = ["blocking"] }
 ```
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ musicbrainz_rs_nova = "0.5.1"
 **blocking client:**
 
 ```toml
-musicbrainz_rs_nova = { version = "0.5.1", features = ["blocking"] }
+musicbrainz_rs_nova = { version = "0.5.1", default-features = false, features = ["blocking"] }
 ```
 
 ## Features


### PR DESCRIPTION
A couple of commits fixing problems in the README, relating to Cargo.toml:

- Old crate name
- Doesn't build in blocking mode with config as originally listed.